### PR TITLE
OSX compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CURLINCL = `curl-config --cflags` 
 JANSINCL = -I/usr/local/include
 
-CURLLIBS = `curl-config --static-libs`
+CURLLIBS = `[ ! -z $$(curl-config --libs) ] && curl-config --libs || curl-config --static-libs`
 JANSLIBS = -L/usr/local/lib -ljansson
 
 CWARN =-W -Wall -Wcast-qual -Wpointer-arith -Wwrite-strings \

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This is a shortened version of the dnsdb query testing tool.
 
 Dependencies:
-	jannson
+	jansson
 	libcurl
 
 On Linux (Debian 7):
@@ -31,6 +31,9 @@ On Linux (CentOS 6):
 On FreeBSD 10:
 	pkg install curl
 	pkg install jansson-2.5
+
+On OSX:
+    brew install jansson
 
 DNSDB Usage:
 	make


### PR DESCRIPTION
This fixes a typo and makes dnsdb_c compile and work on OSX. 